### PR TITLE
show extra info in resoruce links

### DIFF
--- a/src/replay/lib.ts
+++ b/src/replay/lib.ts
@@ -762,7 +762,7 @@ export class Replay {
 let lastReplayObjectKey = 0;
 const replayObjectKeys = new Map<ReplayObject, number>();
 
-class ReplayObject {
+export class ReplayObject {
     replay: Replay;
     label?: string;
 

--- a/src/ui/lib/webgpu-utils.ts
+++ b/src/ui/lib/webgpu-utils.ts
@@ -39,3 +39,8 @@ const gpuTextureUsage = [
 ];
 
 export const gpuTextureUsageToString = (v: number) => bitmaskToString(v, gpuTextureUsage);
+
+export const gpuExtent3DToShortString = (s: GPUExtent3D) => {
+    const sd = s as GPUExtent3DDict;
+    return Array.isArray(s) ? s.toString : `${sd.width || 1},${sd.height || 1},${sd.depthOrArrayLayers || 1}`;
+};


### PR DESCRIPTION
eg.

was

* GPUBuffer:Label
* GPUTexture:Label

now

* GPUBuffer:Label[sz:123,usage:7]
* GPUTexture:Lable[sz:640,480,1,format:rgba8unorm]

Question:
* should this exist?
* should it be a preference setting?
* should it be a per type preference setting?