### PR TITLE
Quick hacky fix so the debugger runs in v1 WebGPU

### DIFF
--- a/src/capture/registry.ts
+++ b/src/capture/registry.ts
@@ -252,8 +252,8 @@ export interface TraceRenderPassDepthStencilAttachment {
 
 export interface TraceCommandBeginRenderPassArgs {
     colorAttachments: TraceRenderPassColorAttachment[];
-    timestampWrites: TraceRenderPassTimestampWrite[];
-    occlusionQuerySetSerial?: number;
+    //timestampWrites: TraceRenderPassTimestampWrite[];
+    //occlusionQuerySetSerial?: number;
     maxDrawCount: number;
     depthStencilAttachment?: TraceRenderPassDepthStencilAttachment;
 }
@@ -1738,18 +1738,18 @@ class RenderPassEncoderState extends BaseState<GPURenderPassEncoder> {
                 };
             }),
 
-            timestampWrites: ((desc.timestampWrites ?? []) as GPURenderPassTimestampWrite[]).map(w => {
-                this.encoder.reference(w.querySet);
-                return {
-                    querySetSerial: tracer.querySets.get(w.querySet)!.traceSerial,
-                    queryIndex: w.queryIndex,
-                    location: w.location,
-                };
-            }),
-
-            occlusionQuerySetSerial: desc.occlusionQuerySet
-                ? tracer.querySets.get(desc.occlusionQuerySet)!.traceSerial
-                : undefined,
+            //timestampWrites: ((desc.timestampWrites ?? []) as GPURenderPassTimestampWrite[]).map(w => {
+            //    this.encoder.reference(w.querySet);
+            //    return {
+            //        querySetSerial: tracer.querySets.get(w.querySet)!.traceSerial,
+            //        queryIndex: w.queryIndex,
+            //        location: w.location,
+            //    };
+            //}),
+            //
+            //occlusionQuerySetSerial: desc.occlusionQuerySet
+            //    ? tracer.querySets.get(desc.occlusionQuerySet)!.traceSerial
+            //    : undefined,
             maxDrawCount: desc.maxDrawCount ?? 50000000, // Yes that's the spec default.
         };
         this.encoder.reference(desc.occlusionQuerySet);

--- a/src/replay/lib.ts
+++ b/src/replay/lib.ts
@@ -136,9 +136,9 @@ export interface ReplayRenderPassDepthStencilAttachment {
 
 export interface ReplayCommandBeginRenderPassArgs {
     colorAttachments: ReplayRenderPassColorAttachment[];
-    timestampWrites: ReplayRenderPassTimestampWrite[];
-    occlusionQuerySet?: GPUQuerySet;
-    occlusionQuerySetState?: ReplayQuerySet;
+    //timestampWrites: ReplayRenderPassTimestampWrite[];
+    //occlusionQuerySet?: GPUQuerySet;
+    //occlusionQuerySetState?: ReplayQuerySet;
     maxDrawCount: number;
     depthStencilAttachment?: ReplayRenderPassDepthStencilAttachment;
 }
@@ -1074,17 +1074,17 @@ export class ReplayCommandBuffer extends ReplayObject {
                         delete ds.viewSerial;
                     }
 
-                    for (const w of c.args.timestampWrites) {
-                        w.querySetState = this.replay.querySets[w.querySetSerial];
-                        w.querySet = w.querySet.webgpuObject;
-                        delete w.querySetSerial;
-                    }
-
-                    if (c.args.occlusionQuerySetSerial !== undefined) {
-                        c.args.occlusionQuerySetState = this.replay.querySets[c.args.occlusionQuerySetSerial];
-                        c.args.occlusionQuerySet = c.args.occlusionQuerySetState;
-                        delete c.args.occlusionQuerySetSerial;
-                    }
+                    //for (const w of c.args.timestampWrites) {
+                    //    w.querySetState = this.replay.querySets[w.querySetSerial];
+                    //    w.querySet = w.querySet.webgpuObject;
+                    //    delete w.querySetSerial;
+                    //}
+                    //
+                    //if (c.args.occlusionQuerySetSerial !== undefined) {
+                    //    c.args.occlusionQuerySetState = this.replay.querySets[c.args.occlusionQuerySetSerial];
+                    //    c.args.occlusionQuerySet = c.args.occlusionQuerySetState;
+                    //    delete c.args.occlusionQuerySetSerial;
+                    //}
 
                     // Special case, add a pseudo-command that's a whole render pass command.
                     const rp = new ReplayRenderPass(this.replay);


### PR DESCRIPTION
The debugger was written 6 months before shipping
and it has a few wrappers of APIs that changed

I didn't bother trying to fix them, I just commented them out.