### PR TITLE
Add support for compute pipelines & update to 1.40 webgpu types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.46.0",
         "@typescript-eslint/parser": "^5.46.0",
-        "@webgpu/types": "^0.1.23",
+        "@webgpu/types": "^0.1.40",
         "chai": "^4.3.7",
         "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.23.tgz",
-      "integrity": "sha512-SxHrhOTH1C7EcbnVZ3DzzliQs10QJO19GoUtzVJLIqDD0VeAdtxLEoNnP5zkCDKyMFvx3ptU7jESdaOIUqAuJg==",
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.40.tgz",
+      "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -6285,9 +6285,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.23.tgz",
-      "integrity": "sha512-SxHrhOTH1C7EcbnVZ3DzzliQs10QJO19GoUtzVJLIqDD0VeAdtxLEoNnP5zkCDKyMFvx3ptU7jESdaOIUqAuJg==",
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.40.tgz",
+      "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw==",
       "dev": true
     },
     "accepts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
-    "@webgpu/types": "^0.1.23",
+    "@webgpu/types": "^0.1.40",
     "chai": "^4.3.7",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",

--- a/src/capture/unwrapped-webgpu.ts
+++ b/src/capture/unwrapped-webgpu.ts
@@ -10,7 +10,7 @@ const mapClassToCreationFunctionNames = new Map<Function, Set<string>>();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 let getUnwrappedDevice = (_: GPUDevice): GPUDevice | undefined => undefined;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-let setUnwrappedDevice = (wrapped: GPUDevice, unwrapped: GPUDevice) => {};
+let setUnwrappedDevice = (wrapped: GPUDevice, unwrapped: GPUDevice) => { };
 
 if (typeof GPUDevice !== 'undefined') {
     if (!GPUDevice.prototype.createBuffer.toString().includes('native')) {
@@ -29,6 +29,8 @@ if (typeof GPUDevice !== 'undefined') {
         GPUQueue,
         GPURenderPassEncoder,
         GPURenderPipeline,
+        GPUComputePipeline,
+        GPUComputePassEncoder,
         GPUTexture,
     ];
 

--- a/src/ui/views/objectViews/ShaderModuleVis/ShaderModuleVis.tsx
+++ b/src/ui/views/objectViews/ShaderModuleVis/ShaderModuleVis.tsx
@@ -32,7 +32,7 @@ export default function ShaderModuleVis({ data }: { data: ReplayShaderModule }) 
 
     return (
         <div className="wgdb-vis">
-            <JsonValueObject data={desc.hints || {}} />
+            <JsonValueObject data={desc.compilationHints || {}} />
             <Checkbox label="raw" checked={raw} onChange={setRaw} />
             <pre>{optionallyRemoveLeadingWhitespace(!raw, desc.code)}</pre>
         </div>


### PR DESCRIPTION
This PR adds support for compute. I basically copied render passes and just did a search and replace. I had to modify bindgroup layouts a little. I opted for storing ids of render and compute pipelines and leaving one of them undefined.

A folded an update to 1.40 of webgpu types if you don't mind. 

Closes https://github.com/webgpu/webgpu-debugger/issues/36